### PR TITLE
Change field name from "code" to "type"

### DIFF
--- a/src/openapi/I_Audit_Event.yaml
+++ b/src/openapi/I_Audit_Event.yaml
@@ -831,7 +831,7 @@ components:
             identifier:
               type: object
               properties:
-                code:
+                type:
                   $ref: '#/components/schemas/CodeableConcept'
                 system:
                   type: string


### PR DESCRIPTION
The "Identifier" object doesn't have a field "code". The only field with type "CodeableConcept" is called "type".

See: https://www.hl7.org/fhir/R4B/datatypes.html#Identifier