### PR TITLE
I_Authorization_Service: Fixed typo in required parameter

### DIFF
--- a/src/openapi/I_Authorization_Service.yaml
+++ b/src/openapi/I_Authorization_Service.yaml
@@ -990,7 +990,7 @@ components:
           $ref: '#/components/schemas/ClientAttestationType'
       required: 
         - authorizationCode
-        - clienatAttest
+        - clientAttest
     SendAuthCodeFdVtype:
       description: Authorization code
       type: object


### PR DESCRIPTION
Came across what is probably a typo. Feel free to merge :)

It's part of the `POST /epa/authz/v1/send_authcode_sc` endpoints request body.